### PR TITLE
refactored build_embedding to handle plain text and formatted links

### DIFF
--- a/lib/report_builder.rb
+++ b/lib/report_builder.rb
@@ -391,27 +391,45 @@ class ReportBuilder
   def self.build_embedding(embeddings)
     @embedding_count ||= 0
     embeddings.each do |embedding|
+      src = Base64.decode64(embedding['data'])
       id = "embedding_#{@embedding_count}"
       if embedding['mime_type'] =~ /^image\/(png|gif|jpg|jpeg)/
-        @builder.span(class: 'image') do
-          @builder.a(href: '', style: 'text-decoration: none;', onclick: "img=document.getElementById('#{id}');img.style.display = (img.style.display == 'none' ? 'block' : 'none');return false") do
-            @builder.span(style: "color: #{COLOR[:output]}; font-weight: bold; border-bottom: 1px solid #{COLOR[:output]};") do
-              @builder << 'Screenshot'
+        begin
+          @builder.span(class: 'image') do
+            @builder.a(href: '', style: 'text-decoration: none;', onclick: "img=document.getElementById('#{id}');img.style.display = (img.style.display == 'none' ? 'block' : 'none');return false") do
+              @builder.span(style: "color: #{COLOR[:output]}; font-weight: bold; border-bottom: 1px solid #{COLOR[:output]};") do
+                @builder << 'Screenshot'
+              end
             end
+            @builder << '<br/>'
+            @options[:compress_images] ? build_unique_image(embedding, id) : build_image(embedding,id)
           end
-          @builder << '<br/>'
-          @options[:compress_images] ? build_unique_image(embedding, id) : build_image(embedding,id) rescue puts 'Image embedding failed!'
+        rescue => e
+          puts 'Image embedding failed!'
+          puts [e.class, e.message, e.backtrace[0..10].join("\n")].join("\n")
         end
       elsif embedding['mime_type'] =~ /^text\/plain/
-        @builder.span(class: 'link') do
-          src = Base64.decode64(embedding['data'])
-          @builder.a(id: id, style: 'text-decoration: none;', href: src, title: 'Link') do
-            @builder.span(style: "color: #{COLOR[:output]}; font-weight: bold; border-bottom: 1px solid #{COLOR[:output]};") do
+        begin
+          if src.include?('|||')
+            title, link = src.split('|||')
+            @builder.span(class: 'link') do
+              @builder.a(id: id, style: 'text-decoration: none;', href: link, title: title) do
+                @builder.span(style: "color: #{COLOR[:output]}; font-weight: bold; border-bottom: 1px solid #{COLOR[:output]};") do
+                  @builder << title
+                end
+              end
+              @builder << '<br/>'
+            end
+          else
+            @builder.span(class: 'info') do
               @builder << src
+              @builder << '<br/>'
             end
           end
-          @builder << '<br/>'
-        end rescue puts('Link embedding skipped!')
+        rescue => e
+          puts('Link embedding skipped!')
+          puts [e.class, e.message, e.backtrace[0..10].join("\n")].join("\n")
+        end
       end
       @embedding_count += 1
     end if embeddings.is_a?(Array)

--- a/lib/report_builder.rb
+++ b/lib/report_builder.rb
@@ -398,7 +398,7 @@ class ReportBuilder
           @builder.span(class: 'image') do
             @builder.a(href: '', style: 'text-decoration: none;', onclick: "img=document.getElementById('#{id}');img.style.display = (img.style.display == 'none' ? 'block' : 'none');return false") do
               @builder.span(style: "color: #{COLOR[:output]}; font-weight: bold; border-bottom: 1px solid #{COLOR[:output]};") do
-                @builder << 'Screenshot'
+                @builder << "Screenshot ##{@embedding_count}"
               end
             end
             @builder << '<br/>'


### PR DESCRIPTION
The way embeddings are added to the html report has a few issues:
- all of the embedded images are labeled 'Screenshot'
- large embedded images are difficult to view in the embedded preview window they load in
- any embedded text is automatically transformed into a link(that doesn't go anywhere)

This PR updates the `build_embedding` function with some fixes and new features:
- plain text embeddings are no longer turned into empty links, but are instead displayed as plain text
- if users embed plain text in the format "Title of link|||link_source", the report will embed a link with the title "Title of link" that points to `link_source`
  - this gives users the flexibility to name images/links however they want and makes it easier to open the image/link in a new window or tab for easier viewing.
- embedded images still work like they did before, but now included iteration numbers in their labels to help differentiate between them
- expanded the `rescue` handlers to include more information to aid debugging